### PR TITLE
pallet-tips | port to frame v2

### DIFF
--- a/.maintain/gitlab/check_polkadot_companion_status.sh
+++ b/.maintain/gitlab/check_polkadot_companion_status.sh
@@ -56,27 +56,7 @@ fi
 boldprint "companion pr: #${pr_companion}"
 
 # check the status of that pull request - needs to be
-# mergable and approved
-
-curl -H "${github_header}" -sS -o companion_pr.json \
-  ${github_api_polkadot_pull_url}/${pr_companion}
-
-pr_head_sha=$(jq -r -e '.head.sha' < companion_pr.json)
-boldprint "Polkadot PR's HEAD SHA: $pr_head_sha"
-
-if jq -e .merged < companion_pr.json >/dev/null
-then
-  boldprint "polkadot pr #${pr_companion} already merged"
-  exit 0
-fi
-
-if jq -e '.mergeable' < companion_pr.json >/dev/null
-then
-  boldprint "polkadot pr #${pr_companion} mergeable"
-else
-  boldprint "polkadot pr #${pr_companion} not mergeable"
-  exit 1
-fi
+# approved and mergable
 
 curl -H "${github_header}" -sS -o companion_pr_reviews.json \
   ${github_api_polkadot_pull_url}/${pr_companion}/reviews
@@ -98,6 +78,25 @@ if [ -z "$(jq -r -e '.[].state | select(. == "APPROVED")' < companion_pr_reviews
 fi
 
 boldprint "polkadot pr #${pr_companion} state APPROVED"
+
+curl -H "${github_header}" -sS -o companion_pr.json \
+  ${github_api_polkadot_pull_url}/${pr_companion}
+
+pr_head_sha=$(jq -r -e '.head.sha' < companion_pr.json)
+boldprint "Polkadot PR's HEAD SHA: $pr_head_sha"
+
+if jq -e .merged < companion_pr.json >/dev/null
+then
+  boldprint "polkadot pr #${pr_companion} already merged"
+  exit 0
+fi
+
+if jq -e '.mergeable' < companion_pr.json >/dev/null
+then
+  boldprint "polkadot pr #${pr_companion} mergeable"
+else
+  boldprint "polkadot pr #${pr_companion} not mergeable"
+  exit 1
+fi
+
 exit 0
-
-

--- a/frame/tips/src/benchmarking.rs
+++ b/frame/tips/src/benchmarking.rs
@@ -22,179 +22,189 @@
 use super::*;
 
 use frame_system::RawOrigin;
-use frame_benchmarking::{benchmarks, account, whitelisted_caller, impl_benchmark_test_suite};
+use frame_benchmarking::{
+    benchmarks,
+    account,
+    whitelisted_caller,
+    impl_benchmark_test_suite,
+};
+use frame_support::{
+    ensure,
+};
 use sp_runtime::{traits::{Saturating}};
 
-use crate::Module as TipsMod;
+use crate::Pallet as TipsMod;
 
 const SEED: u32 = 0;
 
 // Create the pre-requisite information needed to create a `report_awesome`.
 fn setup_awesome<T: Config>(length: u32) -> (T::AccountId, Vec<u8>, T::AccountId) {
-	let caller = whitelisted_caller();
-	let value = T::TipReportDepositBase::get()
-		+ T::DataDepositPerByte::get() * length.into()
-		+ T::Currency::minimum_balance();
-	let _ = T::Currency::make_free_balance_be(&caller, value);
-	let reason = vec![0; length as usize];
-	let awesome_person = account("awesome", 0, SEED);
-	(caller, reason, awesome_person)
+    let caller = whitelisted_caller();
+    let value = T::TipReportDepositBase::get()
+        + T::DataDepositPerByte::get() * length.into()
+        + T::Currency::minimum_balance();
+    let _ = T::Currency::make_free_balance_be(&caller, value);
+    let reason = vec![0; length as usize];
+    let awesome_person = account("awesome", 0, SEED);
+    (caller, reason, awesome_person)
 }
 
 // Create the pre-requisite information needed to call `tip_new`.
 fn setup_tip<T: Config>(r: u32, t: u32) ->
-	Result<(T::AccountId, Vec<u8>, T::AccountId, BalanceOf<T>), &'static str>
+    Result<(T::AccountId, Vec<u8>, T::AccountId, BalanceOf<T>), &'static str>
 {
-	let tippers_count = T::Tippers::count();
+    let tippers_count = T::Tippers::count();
 
-	for i in 0 .. t {
-		let member = account("member", i, SEED);
-		T::Tippers::add(&member);
-		ensure!(T::Tippers::contains(&member), "failed to add tipper");
-	}
+    for i in 0 .. t {
+        let member = account("member", i, SEED);
+        T::Tippers::add(&member);
+        ensure!(T::Tippers::contains(&member), "failed to add tipper");
+    }
 
-	ensure!(T::Tippers::count() == tippers_count + t as usize, "problem creating tippers");
-	let caller = account("member", t - 1, SEED);
-	let reason = vec![0; r as usize];
-	let beneficiary = account("beneficiary", t, SEED);
-	let value = T::Currency::minimum_balance().saturating_mul(100u32.into());
-	Ok((caller, reason, beneficiary, value))
+    ensure!(T::Tippers::count() == tippers_count + t as usize, "problem creating tippers");
+    let caller = account("member", t - 1, SEED);
+    let reason = vec![0; r as usize];
+    let beneficiary = account("beneficiary", t, SEED);
+    let value = T::Currency::minimum_balance().saturating_mul(100u32.into());
+    Ok((caller, reason, beneficiary, value))
 }
 
 // Create `t` new tips for the tip proposal with `hash`.
 // This function automatically makes the tip able to close.
 fn create_tips<T: Config>(t: u32, hash: T::Hash, value: BalanceOf<T>) ->
-	Result<(), &'static str>
+    Result<(), &'static str>
 {
-	for i in 0 .. t {
-		let caller = account("member", i, SEED);
-		ensure!(T::Tippers::contains(&caller), "caller is not a tipper");
-		TipsMod::<T>::tip(RawOrigin::Signed(caller).into(), hash, value)?;
-	}
-	Tips::<T>::mutate(hash, |maybe_tip| {
-		if let Some(open_tip) = maybe_tip {
-			open_tip.closes = Some(T::BlockNumber::zero());
-		}
-	});
-	Ok(())
+    for i in 0 .. t {
+        let caller = account("member", i, SEED);
+        ensure!(T::Tippers::contains(&caller), "caller is not a tipper");
+        TipsMod::<T>::tip(RawOrigin::Signed(caller).into(), hash, value)?;
+    }
+    Tips::<T>::mutate(hash, |maybe_tip| {
+        if let Some(open_tip) = maybe_tip {
+            open_tip.closes = Some(T::BlockNumber::zero());
+        }
+    });
+    Ok(())
 }
 
 fn setup_pot_account<T: Config>() {
-	let pot_account = TipsMod::<T>::account_id();
-	let value = T::Currency::minimum_balance().saturating_mul(1_000_000_000u32.into());
-	let _ = T::Currency::make_free_balance_be(&pot_account, value);
+    let pot_account = TipsMod::<T>::account_id();
+    let value = T::Currency::minimum_balance().saturating_mul(1_000_000_000u32.into());
+    let _ = T::Currency::make_free_balance_be(&pot_account, value);
 }
 
-const MAX_BYTES: u32 = 16384;
+// const MAX_BYTES: u32 = 16384;
+const MAX_BYTES: u32 = 2;
 const MAX_TIPPERS: u32 = 100;
 
 benchmarks! {
-	report_awesome {
-		let r in 0 .. MAX_BYTES;
-		let (caller, reason, awesome_person) = setup_awesome::<T>(r);
-		// Whitelist caller account from further DB operations.
-		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
-	}: _(RawOrigin::Signed(caller), reason, awesome_person)
+    report_awesome {
+        let r in 0 .. MAX_BYTES;
+        let (caller, reason, awesome_person) = setup_awesome::<T>(r);
+        // Whitelist caller account from further DB operations.
+        let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
+        frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
+    }: _(RawOrigin::Signed(caller), reason, awesome_person)
 
-	retract_tip {
-		let r = MAX_BYTES;
-		let (caller, reason, awesome_person) = setup_awesome::<T>(r);
-		TipsMod::<T>::report_awesome(
-			RawOrigin::Signed(caller.clone()).into(),
-			reason.clone(),
-			awesome_person.clone()
-		)?;
-		let reason_hash = T::Hashing::hash(&reason[..]);
-		let hash = T::Hashing::hash_of(&(&reason_hash, &awesome_person));
-		// Whitelist caller account from further DB operations.
-		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
-	}: _(RawOrigin::Signed(caller), hash)
+    retract_tip {
+        let r = MAX_BYTES;
+        let (caller, reason, awesome_person) = setup_awesome::<T>(r);
+        TipsMod::<T>::report_awesome(
+            RawOrigin::Signed(caller.clone()).into(),
+            reason.clone(),
+            awesome_person.clone()
+        )?;
+        let reason_hash = T::Hashing::hash(&reason[..]);
+        let hash = T::Hashing::hash_of(&(&reason_hash, &awesome_person));
+        // Whitelist caller account from further DB operations.
+        let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
+        frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
+    }: _(RawOrigin::Signed(caller), hash)
 
-	tip_new {
-		let r in 0 .. MAX_BYTES;
-		let t in 1 .. MAX_TIPPERS;
+    tip_new {
+        let r in 0 .. MAX_BYTES;
+        let t in 1 .. MAX_TIPPERS;
 
-		let (caller, reason, beneficiary, value) = setup_tip::<T>(r, t)?;
-		// Whitelist caller account from further DB operations.
-		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
-	}: _(RawOrigin::Signed(caller), reason, beneficiary, value)
+        let (caller, reason, beneficiary, value) = setup_tip::<T>(r, t)?;
+        // Whitelist caller account from further DB operations.
+        let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
+        frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
+    }: _(RawOrigin::Signed(caller), reason, beneficiary, value)
 
-	tip {
-		let t in 1 .. MAX_TIPPERS;
-		let (member, reason, beneficiary, value) = setup_tip::<T>(0, t)?;
-		let value = T::Currency::minimum_balance().saturating_mul(100u32.into());
-		TipsMod::<T>::tip_new(
-			RawOrigin::Signed(member).into(),
-			reason.clone(),
-			beneficiary.clone(),
-			value
-		)?;
-		let reason_hash = T::Hashing::hash(&reason[..]);
-		let hash = T::Hashing::hash_of(&(&reason_hash, &beneficiary));
-		ensure!(Tips::<T>::contains_key(hash), "tip does not exist");
-		create_tips::<T>(t - 1, hash.clone(), value)?;
-		let caller = account("member", t - 1, SEED);
-		// Whitelist caller account from further DB operations.
-		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
-	}: _(RawOrigin::Signed(caller), hash, value)
+    tip {
+        let t in 1 .. MAX_TIPPERS;
+        let (member, reason, beneficiary, value) = setup_tip::<T>(0, t)?;
+        let value = T::Currency::minimum_balance().saturating_mul(100u32.into());
+        TipsMod::<T>::tip_new(
+            RawOrigin::Signed(member).into(),
+            reason.clone(),
+            beneficiary.clone(),
+            value
+        )?;
+        let reason_hash = T::Hashing::hash(&reason[..]);
+        let hash = T::Hashing::hash_of(&(&reason_hash, &beneficiary));
+        ensure!(Tips::<T>::contains_key(hash), "tip does not exist");
+        create_tips::<T>(t - 1, hash.clone(), value)?;
+        let caller = account("member", t - 1, SEED);
+        // Whitelist caller account from further DB operations.
+        let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
+        frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
+    }: _(RawOrigin::Signed(caller), hash, value)
 
-	close_tip {
-		let t in 1 .. MAX_TIPPERS;
+    close_tip {
+        let t in 1 .. MAX_TIPPERS;
 
-		// Make sure pot is funded
-		setup_pot_account::<T>();
+        // Make sure pot is funded
+        setup_pot_account::<T>();
 
-		// Set up a new tip proposal
-		let (member, reason, beneficiary, value) = setup_tip::<T>(0, t)?;
-		let value = T::Currency::minimum_balance().saturating_mul(100u32.into());
-		TipsMod::<T>::tip_new(
-			RawOrigin::Signed(member).into(),
-			reason.clone(),
-			beneficiary.clone(),
-			value
-		)?;
+        // Set up a new tip proposal
+        let (member, reason, beneficiary, value) = setup_tip::<T>(0, t)?;
+        let value = T::Currency::minimum_balance().saturating_mul(100u32.into());
+        TipsMod::<T>::tip_new(
+            RawOrigin::Signed(member).into(),
+            reason.clone(),
+            beneficiary.clone(),
+            value
+        )?;
 
-		// Create a bunch of tips
-		let reason_hash = T::Hashing::hash(&reason[..]);
-		let hash = T::Hashing::hash_of(&(&reason_hash, &beneficiary));
-		ensure!(Tips::<T>::contains_key(hash), "tip does not exist");
+        // Create a bunch of tips
+        let reason_hash = T::Hashing::hash(&reason[..]);
+        let hash = T::Hashing::hash_of(&(&reason_hash, &beneficiary));
+        ensure!(Tips::<T>::contains_key(hash), "tip does not exist");
 
-		create_tips::<T>(t, hash.clone(), value)?;
+        create_tips::<T>(t, hash.clone(), value)?;
 
-		let caller = account("caller", t, SEED);
-		// Whitelist caller account from further DB operations.
-		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
-	}: _(RawOrigin::Signed(caller), hash)
+        let caller = account("caller", t, SEED);
+        // Whitelist caller account from further DB operations.
+        let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
+        frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
+    }: _(RawOrigin::Signed(caller), hash)
 
-	slash_tip {
-		let t in 1 .. MAX_TIPPERS;
+    slash_tip {
+        let t in 1 .. MAX_TIPPERS;
 
-		// Make sure pot is funded
-		setup_pot_account::<T>();
+        // Make sure pot is funded
+        setup_pot_account::<T>();
 
-		// Set up a new tip proposal
-		let (member, reason, beneficiary, value) = setup_tip::<T>(0, t)?;
-		let value = T::Currency::minimum_balance().saturating_mul(100u32.into());
-		TipsMod::<T>::tip_new(
-			RawOrigin::Signed(member).into(),
-			reason.clone(),
-			beneficiary.clone(),
-			value
-		)?;
+        // Set up a new tip proposal
+        let (member, reason, beneficiary, value) = setup_tip::<T>(0, t)?;
+        let value = T::Currency::minimum_balance().saturating_mul(100u32.into());
+        TipsMod::<T>::tip_new(
+            RawOrigin::Signed(member).into(),
+            reason.clone(),
+            beneficiary.clone(),
+            value
+        )?;
 
-		let reason_hash = T::Hashing::hash(&reason[..]);
-		let hash = T::Hashing::hash_of(&(&reason_hash, &beneficiary));
-		ensure!(Tips::<T>::contains_key(hash), "tip does not exist");
-	}: _(RawOrigin::Root, hash)
+        let reason_hash = T::Hashing::hash(&reason[..]);
+        let hash = T::Hashing::hash_of(&(&reason_hash, &beneficiary));
+        ensure!(Tips::<T>::contains_key(hash), "tip does not exist");
+    }: _(RawOrigin::Root, hash)
+
 }
 
 impl_benchmark_test_suite!(
-	TipsMod,
-	crate::tests::new_test_ext(),
-	crate::tests::Test,
+    TipsMod,
+    crate::tests::new_test_ext(),
+    crate::tests::Test,
 );

--- a/frame/tips/src/lib.rs
+++ b/frame/tips/src/lib.rs
@@ -54,529 +54,600 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(test)]
 mod tests;
 mod benchmarking;
 pub mod weights;
 
 use sp_std::prelude::*;
-use frame_support::{decl_module, decl_storage, decl_event, ensure, decl_error, Parameter};
-use frame_support::traits::{
-	Currency, Get, ExistenceRequirement::{KeepAlive},
-	ReservableCurrency
-};
 
+use frame_support::{
+    Parameter,
+    storage::migration::{move_storage_from_pallet},
+    traits::{
+        Currency, Get, ExistenceRequirement::{KeepAlive},
+        ReservableCurrency, Contains, ContainsLengthBound,
+        OnUnbalanced, PalletInfo,
+    },
+};
+use frame_system::{self as system};
 use sp_runtime::{ Percent, RuntimeDebug, traits::{
-	Zero, AccountIdConversion, Hash, BadOrigin
+    Zero, AccountIdConversion, Hash, BadOrigin
 }};
-use frame_support::traits::{Contains, ContainsLengthBound, OnUnbalanced, EnsureOrigin};
+#[cfg(feature = "std")]
+use frame_support::traits::GenesisBuild;
+
 use codec::{Encode, Decode};
-use frame_system::{self as system, ensure_signed};
 pub use weights::WeightInfo;
+
+pub use pallet::*;
 
 pub type BalanceOf<T> = pallet_treasury::BalanceOf<T>;
 pub type NegativeImbalanceOf<T> = pallet_treasury::NegativeImbalanceOf<T>;
-
-pub trait Config: frame_system::Config + pallet_treasury::Config {
-	/// Maximum acceptable reason length.
-	type MaximumReasonLength: Get<u32>;
-
-	/// The amount held on deposit per byte within the tip report reason or bounty description.
-	type DataDepositPerByte: Get<BalanceOf<Self>>;
-
-	/// Origin from which tippers must come.
-	///
-	/// `ContainsLengthBound::max_len` must be cost free (i.e. no storage read or heavy operation).
-	type Tippers: Contains<Self::AccountId> + ContainsLengthBound;
-
-	/// The period for which a tip remains open after is has achieved threshold tippers.
-	type TipCountdown: Get<Self::BlockNumber>;
-
-	/// The percent of the final tip which goes to the original reporter of the tip.
-	type TipFindersFee: Get<Percent>;
-
-	/// The amount held on deposit for placing a tip report.
-	type TipReportDepositBase: Get<BalanceOf<Self>>;
-
-	/// The overarching event type.
-	type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
-
-	/// Weight information for extrinsics in this pallet.
-	type WeightInfo: WeightInfo;
-}
 
 /// An open tipping "motion". Retains all details of a tip including information on the finder
 /// and the members who have voted.
 #[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
 pub struct OpenTip<
-	AccountId: Parameter,
-	Balance: Parameter,
-	BlockNumber: Parameter,
-	Hash: Parameter,
+    AccountId: Parameter,
+    Balance: Parameter,
+    BlockNumber: Parameter,
+    Hash: Parameter,
 > {
-	/// The hash of the reason for the tip. The reason should be a human-readable UTF-8 encoded string. A URL would be
-	/// sensible.
-	reason: Hash,
-	/// The account to be tipped.
-	who: AccountId,
-	/// The account who began this tip.
-	finder: AccountId,
-	/// The amount held on deposit for this tip.
-	deposit: Balance,
-	/// The block number at which this tip will close if `Some`. If `None`, then no closing is
-	/// scheduled.
-	closes: Option<BlockNumber>,
-	/// The members who have voted for this tip. Sorted by AccountId.
-	tips: Vec<(AccountId, Balance)>,
-	/// Whether this tip should result in the finder taking a fee.
-	finders_fee: bool,
+    /// The hash of the reason for the tip. The reason should be a human-readable UTF-8 encoded string. A URL would be
+    /// sensible.
+    reason: Hash,
+    /// The account to be tipped.
+    who: AccountId,
+    /// The account who began this tip.
+    finder: AccountId,
+    /// The amount held on deposit for this tip.
+    deposit: Balance,
+    /// The block number at which this tip will close if `Some`. If `None`, then no closing is
+    /// scheduled.
+    closes: Option<BlockNumber>,
+    /// The members who have voted for this tip. Sorted by AccountId.
+    tips: Vec<(AccountId, Balance)>,
+    /// Whether this tip should result in the finder taking a fee.
+    finders_fee: bool,
 }
 
-// Note :: For backward compatability reasons,
-// pallet-tips uses Treasury for storage.
-// This is temporary solution, soon will get replaced with
-// Own storage identifier.
-decl_storage! {
-	trait Store for Module<T: Config> as Treasury {
+#[frame_support::pallet]
+pub mod pallet {
+    use frame_support::pallet_prelude::*;
+    use frame_system::pallet_prelude::*;
+    use super::*;
 
-		/// TipsMap that are not yet completed. Keyed by the hash of `(reason, who)` from the value.
-		/// This has the insecure enumerable hash function since the key itself is already
-		/// guaranteed to be a secure hash.
-		pub Tips get(fn tips):
-			map hasher(twox_64_concat) T::Hash
-			=> Option<OpenTip<T::AccountId, BalanceOf<T>, T::BlockNumber, T::Hash>>;
+    #[pallet::config]
+    pub trait Config: frame_system::Config + pallet_treasury::Config {
 
-		/// Simple preimage lookup from the reason's hash to the original data. Again, has an
-		/// insecure enumerable hash since the key is guaranteed to be the result of a secure hash.
-		pub Reasons get(fn reasons): map hasher(identity) T::Hash => Option<Vec<u8>>;
+        /// Maximum acceptable reason length.
+        type MaximumReasonLength: Get<u32>;
 
-	}
+        /// The overarching event type.
+        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+
+        /// The amount held on deposit per byte within the tip report reason or bounty description.
+        type DataDepositPerByte: Get<BalanceOf<Self>>;
+
+        /// Origin from which tippers must come.
+        ///
+        /// `ContainsLengthBound::max_len` must be cost free (i.e. no storage read or heavy operation).
+        type Tippers: Contains<Self::AccountId> + ContainsLengthBound;
+
+        /// The period for which a tip remains open after is has achieved threshold tippers.
+        type TipCountdown: Get<Self::BlockNumber>;
+
+        /// The percent of the final tip which goes to the original reporter of the tip.
+        type TipFindersFee: Get<Percent>;
+
+        /// The amount held on deposit for placing a tip report.
+        type TipReportDepositBase: Get<BalanceOf<Self>>;
+
+        /// Weight information for extrinsics in this pallet.
+        type WeightInfo: WeightInfo;
+    }
+
+    #[pallet::pallet]
+    #[pallet::generate_store(pub(super) trait Store)]
+    pub struct Pallet<T>(PhantomData<T>);
+
+    #[pallet::hooks]
+    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+
+        fn on_runtime_upgrade() -> frame_support::weights::Weight {
+            if !UpgradedToTripleRefCount::<T>::get() {
+                UpgradedToTripleRefCount::<T>::put(true);
+                migrations::migrate_to_triple_ref_count::<T>()
+            } else {
+                0
+            }
+        }
+
+        fn integrity_test() {
+            T::BlockWeights::get()
+                .validate()
+                .expect("The weights are invalid.");
+        }
+
+    }
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        /// Report something `reason` that deserves a tip and claim any eventual the finder's fee.
+        ///
+        /// The dispatch origin for this call must be _Signed_.
+        ///
+        /// Payment: `TipReportDepositBase` will be reserved from the origin account, as well as
+        /// `DataDepositPerByte` for each byte in `reason`.
+        ///
+        /// - `reason`: The reason for, or the thing that deserves, the tip; generally this will be
+        ///   a UTF-8-encoded URL.
+        /// - `who`: The account which should be credited for the tip.
+        ///
+        /// Emits `NewTip` if successful.
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::report_awesome(reason.len() as u32))]
+        pub fn report_awesome(
+            origin: OriginFor<T>,
+            reason: Vec<u8>,
+            who: T::AccountId
+        ) -> DispatchResultWithPostInfo {
+            let finder = ensure_signed(origin)?;
+
+            ensure!(
+                reason.len() <= T::MaximumReasonLength::get() as usize,
+                Error::<T>::ReasonTooBig
+            );
+
+            let reason_hash = T::Hashing::hash(&reason[..]);
+            ensure!(
+                !<Reasons<T>>::contains_key(&reason_hash),
+                Error::<T>::AlreadyKnown
+            );
+
+            let hash = T::Hashing::hash_of(&(&reason_hash, &who));
+            ensure!(
+                !<Tips<T>>::contains_key(&hash),
+                Error::<T>::AlreadyKnown
+            );
+
+            let deposit = T::TipReportDepositBase::get()
+                + T::DataDepositPerByte::get() * (reason.len() as u32).into();
+            T::Currency::reserve(&finder, deposit)?;
+
+            <Reasons<T>>::insert(&reason_hash, reason);
+            let tip = OpenTip {
+                reason: reason_hash,
+                who,
+                finder,
+                deposit,
+                closes: None,
+                tips: vec![],
+                finders_fee: true
+            };
+            <Tips<T>>::insert(&hash, tip);
+            Self::deposit_event(Event::NewTip(hash));
+            Ok(().into())
+        }
+
+        /// Retract a prior tip-report from `report_awesome`, and cancel the process of tipping.
+        ///
+        /// If successful, the original deposit will be unreserved.
+        ///
+        /// The dispatch origin for this call must be _Signed_ and the tip identified by `hash`
+        /// must have been reported by the signing account through `report_awesome` (and not
+        /// through `tip_new`).
+        ///
+        /// - `hash`: The identity of the open tip for which a tip value is declared. This is formed
+        ///   as the hash of the tuple of the original tip `reason` and the beneficiary account ID.
+        ///
+        /// Emits `TipRetracted` if successful.
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::retract_tip())]
+        pub fn retract_tip(
+            origin: OriginFor<T>,
+            hash: T::Hash
+        ) -> DispatchResultWithPostInfo {
+            let who = ensure_signed(origin)?;
+            let tip = <Tips<T>>::get(&hash).ok_or(Error::<T>::UnknownTip)?;
+            ensure!(tip.finder == who, Error::<T>::NotFinder);
+
+            <Reasons<T>>::remove(&tip.reason);
+            <Tips<T>>::remove(&hash);
+            if !tip.deposit.is_zero() {
+                let err_amount = T::Currency::unreserve(&who, tip.deposit);
+                debug_assert!(err_amount.is_zero());
+            }
+            Self::deposit_event(Event::TipRetracted(hash));
+            Ok(().into())
+        }
+
+        /// Give a tip for something new; no finder's fee will be taken.
+        ///
+        /// The dispatch origin for this call must be _Signed_ and the signing account must be a
+        /// member of the `Tippers` set.
+        ///
+        /// - `reason`: The reason for, or the thing that deserves, the tip; generally this will be
+        ///   a UTF-8-encoded URL.
+        /// - `who`: The account which should be credited for the tip.
+        /// - `tip_value`: The amount of tip that the sender would like to give. The median tip
+        ///   value of active tippers will be given to the `who`.
+        ///
+        /// Emits `NewTip` if successful.
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::tip_new(reason.len() as u32, T::Tippers::max_len() as u32))]
+        pub fn tip_new(
+            origin: OriginFor<T>,
+            reason: Vec<u8>,
+            who: T::AccountId,
+            #[pallet::compact] tip_value: BalanceOf<T>,
+        ) -> DispatchResultWithPostInfo {
+            let tipper = ensure_signed(origin)?;
+            ensure!(T::Tippers::contains(&tipper), BadOrigin);
+
+            let reason_hash = T::Hashing::hash(&reason[..]);
+            ensure!(
+                !Reasons::<T>::contains_key(&reason_hash),
+                Error::<T>::AlreadyKnown,
+            );
+            let hash = T::Hashing::hash_of(&(&reason_hash, &who));
+
+            <Reasons<T>>::insert(&reason_hash, reason);
+            Self::deposit_event(Event::NewTip(hash.clone()));
+            let tips = vec![(tipper.clone(), tip_value)];
+            let tip = OpenTip {
+                reason: reason_hash,
+                who,
+                finder: tipper,
+                deposit: Zero::zero(),
+                closes: None,
+                tips,
+                finders_fee: false,
+            };
+            <Tips<T>>::insert(&hash, tip);
+            Ok(().into())
+        }
+
+        /// Declare a tip value for an already-open tip.
+        ///
+        /// The dispatch origin for this call must be _Signed_ and the signing account must be a
+        /// member of the `Tippers` set.
+        ///
+        /// - `hash`: The identity of the open tip for which a tip value is declared. This is formed
+        ///   as the hash of the tuple of the hash of the original tip `reason` and the beneficiary
+        ///   account ID.
+        /// - `tip_value`: The amount of tip that the sender would like to give. The median tip
+        ///   value of active tippers will be given to the `who`.
+        ///
+        /// Emits `TipClosing` if the threshold of tippers has been reached and the countdown period
+        /// has started.
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::tip(T::Tippers::max_len() as u32))]
+        pub fn tip(
+            origin: OriginFor<T>,
+            hash: T::Hash,
+            #[pallet::compact] tip_value: BalanceOf<T>
+        ) -> DispatchResultWithPostInfo {
+            let tipper = ensure_signed(origin)?;
+            ensure!(T::Tippers::contains(&tipper), BadOrigin);
+
+            let mut tip = <Tips<T>>::get(hash).ok_or(Error::<T>::UnknownTip)?;
+            if Self::insert_tip_and_check_closing(&mut tip, tipper, tip_value) {
+                Self::deposit_event(Event::TipClosing(hash.clone()));
+            }
+            <Tips<T>>::insert(&hash, tip);
+            Ok(().into())
+        }
+
+        /// Close and payout a tip.
+        ///
+        /// The dispatch origin for this call must be _Signed_.
+        ///
+        /// The tip identified by `hash` must have finished its countdown period.
+        ///
+        /// - `hash`: The identity of the open tip for which a tip value is declared. This is formed
+        ///   as the hash of the tuple of the original tip `reason` and the beneficiary account ID.
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::close_tip(T::Tippers::max_len() as u32))]
+        pub fn close_tip(
+            origin: OriginFor<T>,
+            hash: T::Hash
+        ) -> DispatchResultWithPostInfo {
+            ensure_signed(origin)?;
+
+            let tip = <Tips<T>>::get(hash).ok_or(Error::<T>::UnknownTip)?;
+            let n = tip.closes.as_ref().ok_or(Error::<T>::StillOpen)?;
+            ensure!(
+                // system::Module::<T>::block_number() >= *n,
+                system::Pallet::<T>::block_number() >= *n,
+                Error::<T>::Premature
+            );
+            // closed.
+            <Reasons<T>>::remove(&tip.reason);
+            <Tips<T>>::remove(hash);
+            Self::payout_tip(hash, tip);
+            Ok(().into())
+        }
+
+        /// Remove and slash an already-open tip.
+        ///
+        /// May only be called from `T::RejectOrigin`.
+        ///
+        /// As a result, the finder is slashed and the deposits are lost.
+        ///
+        /// Emits `TipSlashed` if successful.
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::slash_tip(T::Tippers::max_len() as u32))]
+        pub fn slash_tip(
+            origin: OriginFor<T>,
+            hash: T::Hash
+        ) -> DispatchResultWithPostInfo {
+            T::RejectOrigin::ensure_origin(origin)?;
+
+            let tip = <Tips<T>>::take(hash).ok_or(Error::<T>::UnknownTip)?;
+
+            if !tip.deposit.is_zero() {
+                let imbalance = T::Currency::slash_reserved(&tip.finder, tip.deposit).0;
+                T::OnSlash::on_unbalanced(imbalance);
+            }
+            <Reasons<T>>::remove(&tip.reason);
+            Self::deposit_event(Event::TipSlashed(hash, tip.finder, tip.deposit));
+            Ok(().into())
+        }
+
+    }
+
+    #[pallet::error]
+    pub enum Error<T> {
+        /// The reason given is just too big.
+        ReasonTooBig,
+        /// The tip was already found/started.
+        AlreadyKnown,
+        /// The tip hash is unknown.
+        UnknownTip,
+        /// The account attempting to retract the tip is not the finder of the tip.
+        NotFinder,
+        /// The tip cannot be claimed/closed because there are not enough tippers yet.
+        StillOpen,
+        /// The tip cannot be claimed/closed because it's still in the countdown period.
+        Premature,
+    }
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    #[pallet::metadata(T::AccountId = "AccountId", BalanceOf<T> = "Balance", T::Hash = "Hash")]
+    pub enum Event<T: Config> {
+        /// A new tip suggestion has been opened. \[tip_hash\]
+        NewTip(T::Hash),
+        /// A tip suggestion has reached threshold and is closing. \[tip_hash\]
+        TipClosing(T::Hash),
+        /// A tip suggestion has been closed. \[tip_hash, who, payout\]
+        TipClosed(T::Hash, T::AccountId, BalanceOf<T>),
+        /// A tip suggestion has been retracted. \[tip_hash\]
+        TipRetracted(T::Hash),
+        /// A tip suggestion has been slashed. \[tip_hash, finder, deposit\]
+        TipSlashed(T::Hash, T::AccountId, BalanceOf<T>),
+    }
+
+    #[pallet::storage]
+    #[pallet::getter(fn tips)]
+    pub type Tips<T: Config> = StorageMap<
+        _,
+        Twox64Concat,
+        T::Hash,
+        OpenTip<T::AccountId, BalanceOf<T>, T::BlockNumber, T::Hash>,
+        OptionQuery,
+    >;
+
+    #[pallet::storage]
+    #[pallet::getter(fn reasons)]
+    pub type Reasons<T: Config> = StorageMap<
+        _,
+        Twox64Concat,
+        T::Hash,
+        Vec<u8>,
+        OptionQuery,
+    >;
+
+    /// True if we have upgraded so that AccountInfo contains three types of `RefCount`. False
+    /// (default) if not.
+    #[pallet::storage]
+    pub(super) type UpgradedToTripleRefCount<T: Config> = StorageValue<_, bool, ValueQuery>;
+
+    // TODO :: Have to recheck
+    // Since each pallet is has own storage
+    // Tips is expected to have own storage & not
+    // Share with Treasury.
+    #[pallet::genesis_config]
+    pub struct GenesisConfig<T: Config>{
+        pub phantom: sp_std::marker::PhantomData<T>,
+    }
+
+    #[cfg(feature = "std")]
+    impl<T: Config> Default for GenesisConfig<T> {
+        fn default() -> Self {
+            Self {
+                phantom: Default::default(),
+            }
+        }
+    }
+
+    #[pallet::genesis_build]
+    impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+        fn build(&self) {
+            <UpgradedToTripleRefCount<T>>::put(false);
+        }
+    }
 }
 
-decl_event!(
-	pub enum Event<T>
-	where
-		Balance = BalanceOf<T>,
-		<T as frame_system::Config>::AccountId,
-		<T as frame_system::Config>::Hash,
-	{
-		/// A new tip suggestion has been opened. \[tip_hash\]
-		NewTip(Hash),
-		/// A tip suggestion has reached threshold and is closing. \[tip_hash\]
-		TipClosing(Hash),
-		/// A tip suggestion has been closed. \[tip_hash, who, payout\]
-		TipClosed(Hash, AccountId, Balance),
-		/// A tip suggestion has been retracted. \[tip_hash\]
-		TipRetracted(Hash),
-		/// A tip suggestion has been slashed. \[tip_hash, finder, deposit\]
-		TipSlashed(Hash, AccountId, Balance),
-	}
-);
+mod migrations {
+    use super::*;
 
-decl_error! {
-	/// Error for the tips module.
-	pub enum Error for Module<T: Config> {
-		/// The reason given is just too big.
-		ReasonTooBig,
-		/// The tip was already found/started.
-		AlreadyKnown,
-		/// The tip hash is unknown.
-		UnknownTip,
-		/// The account attempting to retract the tip is not the finder of the tip.
-		NotFinder,
-		/// The tip cannot be claimed/closed because there are not enough tippers yet.
-		StillOpen,
-		/// The tip cannot be claimed/closed because it's still in the countdown period.
-		Premature,
-	}
+    /// Migrate from dual `u32` reference counting to triple `u32` reference counting.
+    pub fn migrate_to_triple_ref_count<T: Config>() -> frame_support::weights::Weight {
+
+        let new_name = T::PalletInfo::name::<Pallet<T>>()
+            .expect("Fatal Error Invalid PalletInfo name");
+        move_storage_from_pallet(b"Tips", b"Treasury", new_name.as_bytes());
+        move_storage_from_pallet(b"Reasons", b"Treasury", new_name.as_bytes());
+
+        T::BlockWeights::get().max_block
+    }
 }
 
-decl_module! {
-	pub struct Module<T: Config>
-		for enum Call
-		where origin: T::Origin
-	{
+#[cfg(feature = "std")]
+impl<T: Config> GenesisConfig<T> {
+    /// Direct implementation of `GenesisBuild::build_storage`.
+    ///
+    /// Kept in order not to break dependency.
+    pub fn build_storage(&self) -> Result<sp_runtime::Storage, String> {
+        <Self as GenesisBuild<T>>::build_storage(self)
+    }
 
-		/// The period for which a tip remains open after is has achieved threshold tippers.
-		const TipCountdown: T::BlockNumber = T::TipCountdown::get();
-
-		/// The amount of the final tip which goes to the original reporter of the tip.
-		const TipFindersFee: Percent = T::TipFindersFee::get();
-
-		/// The amount held on deposit for placing a tip report.
-		const TipReportDepositBase: BalanceOf<T> = T::TipReportDepositBase::get();
-
-		/// The amount held on deposit per byte within the tip report reason.
-		const DataDepositPerByte: BalanceOf<T> = T::DataDepositPerByte::get();
-
-		/// Maximum acceptable reason length.
-		const MaximumReasonLength: u32 = T::MaximumReasonLength::get();
-
-		type Error = Error<T>;
-
-		fn deposit_event() = default;
-
-		/// Report something `reason` that deserves a tip and claim any eventual the finder's fee.
-		///
-		/// The dispatch origin for this call must be _Signed_.
-		///
-		/// Payment: `TipReportDepositBase` will be reserved from the origin account, as well as
-		/// `DataDepositPerByte` for each byte in `reason`.
-		///
-		/// - `reason`: The reason for, or the thing that deserves, the tip; generally this will be
-		///   a UTF-8-encoded URL.
-		/// - `who`: The account which should be credited for the tip.
-		///
-		/// Emits `NewTip` if successful.
-		///
-		/// # <weight>
-		/// - Complexity: `O(R)` where `R` length of `reason`.
-		///   - encoding and hashing of 'reason'
-		/// - DbReads: `Reasons`, `Tips`
-		/// - DbWrites: `Reasons`, `Tips`
-		/// # </weight>
-		#[weight = <T as Config>::WeightInfo::report_awesome(reason.len() as u32)]
-		fn report_awesome(origin, reason: Vec<u8>, who: T::AccountId) {
-			let finder = ensure_signed(origin)?;
-
-			ensure!(reason.len() <= T::MaximumReasonLength::get() as usize, Error::<T>::ReasonTooBig);
-
-			let reason_hash = T::Hashing::hash(&reason[..]);
-			ensure!(!Reasons::<T>::contains_key(&reason_hash), Error::<T>::AlreadyKnown);
-			let hash = T::Hashing::hash_of(&(&reason_hash, &who));
-			ensure!(!Tips::<T>::contains_key(&hash), Error::<T>::AlreadyKnown);
-
-			let deposit = T::TipReportDepositBase::get()
-				+ T::DataDepositPerByte::get() * (reason.len() as u32).into();
-			T::Currency::reserve(&finder, deposit)?;
-
-			Reasons::<T>::insert(&reason_hash, &reason);
-			let tip = OpenTip {
-				reason: reason_hash,
-				who,
-				finder,
-				deposit,
-				closes: None,
-				tips: vec![],
-				finders_fee: true
-			};
-			Tips::<T>::insert(&hash, tip);
-			Self::deposit_event(RawEvent::NewTip(hash));
-		}
-
-		/// Retract a prior tip-report from `report_awesome`, and cancel the process of tipping.
-		///
-		/// If successful, the original deposit will be unreserved.
-		///
-		/// The dispatch origin for this call must be _Signed_ and the tip identified by `hash`
-		/// must have been reported by the signing account through `report_awesome` (and not
-		/// through `tip_new`).
-		///
-		/// - `hash`: The identity of the open tip for which a tip value is declared. This is formed
-		///   as the hash of the tuple of the original tip `reason` and the beneficiary account ID.
-		///
-		/// Emits `TipRetracted` if successful.
-		///
-		/// # <weight>
-		/// - Complexity: `O(1)`
-		///   - Depends on the length of `T::Hash` which is fixed.
-		/// - DbReads: `Tips`, `origin account`
-		/// - DbWrites: `Reasons`, `Tips`, `origin account`
-		/// # </weight>
-		#[weight = <T as Config>::WeightInfo::retract_tip()]
-		fn retract_tip(origin, hash: T::Hash) {
-			let who = ensure_signed(origin)?;
-			let tip = Tips::<T>::get(&hash).ok_or(Error::<T>::UnknownTip)?;
-			ensure!(tip.finder == who, Error::<T>::NotFinder);
-
-			Reasons::<T>::remove(&tip.reason);
-			Tips::<T>::remove(&hash);
-			if !tip.deposit.is_zero() {
-				let err_amount = T::Currency::unreserve(&who, tip.deposit);
-				debug_assert!(err_amount.is_zero());
-			}
-			Self::deposit_event(RawEvent::TipRetracted(hash));
-		}
-
-		/// Give a tip for something new; no finder's fee will be taken.
-		///
-		/// The dispatch origin for this call must be _Signed_ and the signing account must be a
-		/// member of the `Tippers` set.
-		///
-		/// - `reason`: The reason for, or the thing that deserves, the tip; generally this will be
-		///   a UTF-8-encoded URL.
-		/// - `who`: The account which should be credited for the tip.
-		/// - `tip_value`: The amount of tip that the sender would like to give. The median tip
-		///   value of active tippers will be given to the `who`.
-		///
-		/// Emits `NewTip` if successful.
-		///
-		/// # <weight>
-		/// - Complexity: `O(R + T)` where `R` length of `reason`, `T` is the number of tippers.
-		///   - `O(T)`: decoding `Tipper` vec of length `T`
-		///     `T` is charged as upper bound given by `ContainsLengthBound`.
-		///     The actual cost depends on the implementation of `T::Tippers`.
-		///   - `O(R)`: hashing and encoding of reason of length `R`
-		/// - DbReads: `Tippers`, `Reasons`
-		/// - DbWrites: `Reasons`, `Tips`
-		/// # </weight>
-		#[weight = <T as Config>::WeightInfo::tip_new(reason.len() as u32, T::Tippers::max_len() as u32)]
-		fn tip_new(origin, reason: Vec<u8>, who: T::AccountId, #[compact] tip_value: BalanceOf<T>) {
-			let tipper = ensure_signed(origin)?;
-			ensure!(T::Tippers::contains(&tipper), BadOrigin);
-			let reason_hash = T::Hashing::hash(&reason[..]);
-			ensure!(!Reasons::<T>::contains_key(&reason_hash), Error::<T>::AlreadyKnown);
-			let hash = T::Hashing::hash_of(&(&reason_hash, &who));
-
-			Reasons::<T>::insert(&reason_hash, &reason);
-			Self::deposit_event(RawEvent::NewTip(hash.clone()));
-			let tips = vec![(tipper.clone(), tip_value)];
-			let tip = OpenTip {
-				reason: reason_hash,
-				who,
-				finder: tipper,
-				deposit: Zero::zero(),
-				closes: None,
-				tips,
-				finders_fee: false,
-			};
-			Tips::<T>::insert(&hash, tip);
-		}
-
-		/// Declare a tip value for an already-open tip.
-		///
-		/// The dispatch origin for this call must be _Signed_ and the signing account must be a
-		/// member of the `Tippers` set.
-		///
-		/// - `hash`: The identity of the open tip for which a tip value is declared. This is formed
-		///   as the hash of the tuple of the hash of the original tip `reason` and the beneficiary
-		///   account ID.
-		/// - `tip_value`: The amount of tip that the sender would like to give. The median tip
-		///   value of active tippers will be given to the `who`.
-		///
-		/// Emits `TipClosing` if the threshold of tippers has been reached and the countdown period
-		/// has started.
-		///
-		/// # <weight>
-		/// - Complexity: `O(T)` where `T` is the number of tippers.
-		///   decoding `Tipper` vec of length `T`, insert tip and check closing,
-		///   `T` is charged as upper bound given by `ContainsLengthBound`.
-		///   The actual cost depends on the implementation of `T::Tippers`.
-		///
-		///   Actually weight could be lower as it depends on how many tips are in `OpenTip` but it
-		///   is weighted as if almost full i.e of length `T-1`.
-		/// - DbReads: `Tippers`, `Tips`
-		/// - DbWrites: `Tips`
-		/// # </weight>
-		#[weight = <T as Config>::WeightInfo::tip(T::Tippers::max_len() as u32)]
-		fn tip(origin, hash: T::Hash, #[compact] tip_value: BalanceOf<T>) {
-			let tipper = ensure_signed(origin)?;
-			ensure!(T::Tippers::contains(&tipper), BadOrigin);
-
-			let mut tip = Tips::<T>::get(hash).ok_or(Error::<T>::UnknownTip)?;
-			if Self::insert_tip_and_check_closing(&mut tip, tipper, tip_value) {
-				Self::deposit_event(RawEvent::TipClosing(hash.clone()));
-			}
-			Tips::<T>::insert(&hash, tip);
-		}
-
-		/// Close and payout a tip.
-		///
-		/// The dispatch origin for this call must be _Signed_.
-		///
-		/// The tip identified by `hash` must have finished its countdown period.
-		///
-		/// - `hash`: The identity of the open tip for which a tip value is declared. This is formed
-		///   as the hash of the tuple of the original tip `reason` and the beneficiary account ID.
-		///
-		/// # <weight>
-		/// - Complexity: `O(T)` where `T` is the number of tippers.
-		///   decoding `Tipper` vec of length `T`.
-		///   `T` is charged as upper bound given by `ContainsLengthBound`.
-		///   The actual cost depends on the implementation of `T::Tippers`.
-		/// - DbReads: `Tips`, `Tippers`, `tip finder`
-		/// - DbWrites: `Reasons`, `Tips`, `Tippers`, `tip finder`
-		/// # </weight>
-		#[weight = <T as Config>::WeightInfo::close_tip(T::Tippers::max_len() as u32)]
-		fn close_tip(origin, hash: T::Hash) {
-			ensure_signed(origin)?;
-
-			let tip = Tips::<T>::get(hash).ok_or(Error::<T>::UnknownTip)?;
-			let n = tip.closes.as_ref().ok_or(Error::<T>::StillOpen)?;
-			ensure!(system::Pallet::<T>::block_number() >= *n, Error::<T>::Premature);
-			// closed.
-			Reasons::<T>::remove(&tip.reason);
-			Tips::<T>::remove(hash);
-			Self::payout_tip(hash, tip);
-		}
-
-		/// Remove and slash an already-open tip.
-		///
-		/// May only be called from `T::RejectOrigin`.
-		///
-		/// As a result, the finder is slashed and the deposits are lost.
-		///
-		/// Emits `TipSlashed` if successful.
-		///
-		/// # <weight>
-		///   `T` is charged as upper bound given by `ContainsLengthBound`.
-		///   The actual cost depends on the implementation of `T::Tippers`.
-		/// # </weight>
-		#[weight = <T as Config>::WeightInfo::slash_tip(T::Tippers::max_len() as u32)]
-		fn slash_tip(origin, hash: T::Hash) {
-			T::RejectOrigin::ensure_origin(origin)?;
-
-			let tip = Tips::<T>::take(hash).ok_or(Error::<T>::UnknownTip)?;
-
-			if !tip.deposit.is_zero() {
-				let imbalance = T::Currency::slash_reserved(&tip.finder, tip.deposit).0;
-				T::OnSlash::on_unbalanced(imbalance);
-			}
-			Reasons::<T>::remove(&tip.reason);
-			Self::deposit_event(RawEvent::TipSlashed(hash, tip.finder, tip.deposit));
-		}
-	}
+    /// Direct implementation of `GenesisBuild::assimilate_storage`.
+    ///
+    /// Kept in order not to break dependency.
+    pub fn assimilate_storage(
+        &self,
+        storage: &mut sp_runtime::Storage
+    ) -> Result<(), String> {
+        <Self as GenesisBuild<T>>::assimilate_storage(self, storage)
+    }
 }
 
-impl<T: Config> Module<T> {
-	// Add public immutables and private mutables.
+impl<T: Config>  Pallet<T> {
+    /// The account ID of the treasury pot.
+    ///
+    /// This actually does computation. If you need to keep using it, then make sure you cache the
+    /// value and only call this once.
+    pub fn account_id() -> T::AccountId {
+        T::ModuleId::get().into_account()
+    }
 
-	/// The account ID of the treasury pot.
-	///
-	/// This actually does computation. If you need to keep using it, then make sure you cache the
-	/// value and only call this once.
-	pub fn account_id() -> T::AccountId {
-		T::ModuleId::get().into_account()
-	}
+    /// Given a mutable reference to an `OpenTip`, insert the tip into it and check whether it
+    /// closes, if so, then deposit the relevant event and set closing accordingly.
+    ///
+    /// `O(T)` and one storage access.
+    fn insert_tip_and_check_closing(
+        tip: &mut OpenTip<T::AccountId, BalanceOf<T>, T::BlockNumber, T::Hash>,
+        tipper: T::AccountId,
+        tip_value: BalanceOf<T>,
+    ) -> bool {
+        match tip.tips.binary_search_by_key(&&tipper, |x| &x.0) {
+            Ok(pos) => tip.tips[pos] = (tipper, tip_value),
+            Err(pos) => tip.tips.insert(pos, (tipper, tip_value)),
+        }
+        Self::retain_active_tips(&mut tip.tips);
+        let threshold = (T::Tippers::count() + 1) / 2;
+        if tip.tips.len() >= threshold && tip.closes.is_none() {
+            tip.closes = Some(system::Pallet::<T>::block_number() + T::TipCountdown::get());
+            true
+        } else {
+            false
+        }
+    }
 
-	/// Given a mutable reference to an `OpenTip`, insert the tip into it and check whether it
-	/// closes, if so, then deposit the relevant event and set closing accordingly.
-	///
-	/// `O(T)` and one storage access.
-	fn insert_tip_and_check_closing(
-		tip: &mut OpenTip<T::AccountId, BalanceOf<T>, T::BlockNumber, T::Hash>,
-		tipper: T::AccountId,
-		tip_value: BalanceOf<T>,
-	) -> bool {
-		match tip.tips.binary_search_by_key(&&tipper, |x| &x.0) {
-			Ok(pos) => tip.tips[pos] = (tipper, tip_value),
-			Err(pos) => tip.tips.insert(pos, (tipper, tip_value)),
-		}
-		Self::retain_active_tips(&mut tip.tips);
-		let threshold = (T::Tippers::count() + 1) / 2;
-		if tip.tips.len() >= threshold && tip.closes.is_none() {
-			tip.closes = Some(system::Pallet::<T>::block_number() + T::TipCountdown::get());
-			true
-		} else {
-			false
-		}
-	}
+    /// Remove any non-members of `Tippers` from a `tips` vector. `O(T)`.
+    fn retain_active_tips(tips: &mut Vec<(T::AccountId, BalanceOf<T>)>) {
+        let members = T::Tippers::sorted_members();
+        let mut members_iter = members.iter();
+        let mut member = members_iter.next();
+        tips.retain(|(ref a, _)| loop {
+            match member {
+                None => break false,
+                Some(m) if m > a => break false,
+                Some(m) => {
+                    member = members_iter.next();
+                    if m < a {
+                        continue
+                    } else {
+                        break true;
+                    }
+                }
+            }
+        });
+    }
 
-	/// Remove any non-members of `Tippers` from a `tips` vector. `O(T)`.
-	fn retain_active_tips(tips: &mut Vec<(T::AccountId, BalanceOf<T>)>) {
-		let members = T::Tippers::sorted_members();
-		let mut members_iter = members.iter();
-		let mut member = members_iter.next();
-		tips.retain(|(ref a, _)| loop {
-			match member {
-				None => break false,
-				Some(m) if m > a => break false,
-				Some(m) => {
-					member = members_iter.next();
-					if m < a {
-						continue
-					} else {
-						break true;
-					}
-				}
-			}
-		});
-	}
+    /// Execute the payout of a tip.
+    ///
+    /// Up to three balance operations.
+    /// Plus `O(T)` (`T` is Tippers length).
+    fn payout_tip(hash: T::Hash, tip: OpenTip<T::AccountId, BalanceOf<T>, T::BlockNumber, T::Hash>) {
+        let mut tips = tip.tips;
+        Self::retain_active_tips(&mut tips);
+        tips.sort_by_key(|i| i.1);
 
-	/// Execute the payout of a tip.
-	///
-	/// Up to three balance operations.
-	/// Plus `O(T)` (`T` is Tippers length).
-	fn payout_tip(hash: T::Hash, tip: OpenTip<T::AccountId, BalanceOf<T>, T::BlockNumber, T::Hash>) {
-		let mut tips = tip.tips;
-		Self::retain_active_tips(&mut tips);
-		tips.sort_by_key(|i| i.1);
+        let treasury = Self::account_id();
+        // let max_payout = pallet_treasury::Module::<T>::pot();
+        let max_payout = pallet_treasury::Pallet::<T>::pot();
 
-		let treasury = Self::account_id();
-		let max_payout = pallet_treasury::Module::<T>::pot();
+        let mut payout = tips[tips.len() / 2].1.min(max_payout);
+        if !tip.deposit.is_zero() {
+            let err_amount = T::Currency::unreserve(&tip.finder, tip.deposit);
+            debug_assert!(err_amount.is_zero());
+        }
 
-		let mut payout = tips[tips.len() / 2].1.min(max_payout);
-		if !tip.deposit.is_zero() {
-			let err_amount = T::Currency::unreserve(&tip.finder, tip.deposit);
-			debug_assert!(err_amount.is_zero());
-		}
+        if tip.finders_fee && tip.finder != tip.who {
+            // pay out the finder's fee.
+            let finders_fee = T::TipFindersFee::get() * payout;
+            payout -= finders_fee;
+            // this should go through given we checked it's at most the free balance, but still
+            // we only make a best-effort.
+            let res = T::Currency::transfer(&treasury, &tip.finder, finders_fee, KeepAlive);
+            debug_assert!(res.is_ok());
+        }
 
-		if tip.finders_fee && tip.finder != tip.who {
-			// pay out the finder's fee.
-			let finders_fee = T::TipFindersFee::get() * payout;
-			payout -= finders_fee;
-			// this should go through given we checked it's at most the free balance, but still
-			// we only make a best-effort.
-			let res = T::Currency::transfer(&treasury, &tip.finder, finders_fee, KeepAlive);
-			debug_assert!(res.is_ok());
-		}
+        // same as above: best-effort only.
+        let res = T::Currency::transfer(&treasury, &tip.who, payout, KeepAlive);
+        debug_assert!(res.is_ok());
+        Self::deposit_event(Event::TipClosed(hash, tip.who, payout));
+    }
 
-		// same as above: best-effort only.
-		let res = T::Currency::transfer(&treasury, &tip.who, payout, KeepAlive);
-		debug_assert!(res.is_ok());
-		Self::deposit_event(RawEvent::TipClosed(hash, tip.who, payout));
-	}
+    pub fn migrate_retract_tip_for_tip_new() {
+        /// An open tipping "motion". Retains all details of a tip including information on the finder
+        /// and the members who have voted.
+        #[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+        pub struct OldOpenTip<
+            AccountId: Parameter,
+            Balance: Parameter,
+            BlockNumber: Parameter,
+            Hash: Parameter,
+        > {
+            /// The hash of the reason for the tip. The reason should be a human-readable UTF-8 encoded string. A URL would be
+            /// sensible.
+            reason: Hash,
+            /// The account to be tipped.
+            who: AccountId,
+            /// The account who began this tip and the amount held on deposit.
+            finder: Option<(AccountId, Balance)>,
+            /// The block number at which this tip will close if `Some`. If `None`, then no closing is
+            /// scheduled.
+            closes: Option<BlockNumber>,
+            /// The members who have voted for this tip. Sorted by AccountId.
+            tips: Vec<(AccountId, Balance)>,
+        }
 
-	pub fn migrate_retract_tip_for_tip_new() {
-		/// An open tipping "motion". Retains all details of a tip including information on the finder
-		/// and the members who have voted.
-		#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
-		pub struct OldOpenTip<
-			AccountId: Parameter,
-			Balance: Parameter,
-			BlockNumber: Parameter,
-			Hash: Parameter,
-		> {
-			/// The hash of the reason for the tip. The reason should be a human-readable UTF-8 encoded string. A URL would be
-			/// sensible.
-			reason: Hash,
-			/// The account to be tipped.
-			who: AccountId,
-			/// The account who began this tip and the amount held on deposit.
-			finder: Option<(AccountId, Balance)>,
-			/// The block number at which this tip will close if `Some`. If `None`, then no closing is
-			/// scheduled.
-			closes: Option<BlockNumber>,
-			/// The members who have voted for this tip. Sorted by AccountId.
-			tips: Vec<(AccountId, Balance)>,
-		}
+        use frame_support::{Twox64Concat, migration::StorageKeyIterator};
 
-		use frame_support::{Twox64Concat, migration::StorageKeyIterator};
-
-		for (hash, old_tip) in StorageKeyIterator::<
-			T::Hash,
-			OldOpenTip<T::AccountId, BalanceOf<T>, T::BlockNumber, T::Hash>,
-			Twox64Concat,
-		>::new(b"Treasury", b"Tips").drain()
-		{
-
-			let (finder, deposit, finders_fee) = match old_tip.finder {
-				Some((finder, deposit)) => {
-					(finder, deposit, true)
-				},
-				None => {
-					(T::AccountId::default(), Zero::zero(), false)
-				},
-			};
-			let new_tip = OpenTip {
-				reason: old_tip.reason,
-				who: old_tip.who,
-				finder,
-				deposit,
-				closes: old_tip.closes,
-				tips: old_tip.tips,
-				finders_fee
-			};
-			Tips::<T>::insert(hash, new_tip)
-		}
-	}
+        for (hash, old_tip) in StorageKeyIterator::<
+            T::Hash,
+            OldOpenTip<T::AccountId, BalanceOf<T>, T::BlockNumber, T::Hash>,
+            Twox64Concat,
+        >::new(b"Tips", b"Tips").drain()
+        {
+            let (finder, deposit, finders_fee) = match old_tip.finder {
+                Some((finder, deposit)) => {
+                    (finder, deposit, true)
+                },
+                None => {
+                    (T::AccountId::default(), Zero::zero(), false)
+                },
+            };
+            let new_tip = OpenTip {
+                reason: old_tip.reason,
+                who: old_tip.who,
+                finder,
+                deposit,
+                closes: old_tip.closes,
+                tips: old_tip.tips,
+                finders_fee
+            };
+            Tips::<T>::insert(hash, new_tip)
+        }
+    }
 }

--- a/frame/tips/src/lib.rs
+++ b/frame/tips/src/lib.rs
@@ -122,12 +122,14 @@ pub mod pallet {
     pub trait Config: frame_system::Config + pallet_treasury::Config {
 
         /// Maximum acceptable reason length.
+        #[pallet::constant]
         type MaximumReasonLength: Get<u32>;
 
         /// The overarching event type.
         type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 
         /// The amount held on deposit per byte within the tip report reason or bounty description.
+        #[pallet::constant]
         type DataDepositPerByte: Get<BalanceOf<Self>>;
 
         /// Origin from which tippers must come.
@@ -136,12 +138,15 @@ pub mod pallet {
         type Tippers: Contains<Self::AccountId> + ContainsLengthBound;
 
         /// The period for which a tip remains open after is has achieved threshold tippers.
+        #[pallet::constant]
         type TipCountdown: Get<Self::BlockNumber>;
 
         /// The percent of the final tip which goes to the original reporter of the tip.
+        #[pallet::constant]
         type TipFindersFee: Get<Percent>;
 
         /// The amount held on deposit for placing a tip report.
+        #[pallet::constant]
         type TipReportDepositBase: Get<BalanceOf<Self>>;
 
         /// Weight information for extrinsics in this pallet.

--- a/frame/tips/src/tests.rs
+++ b/frame/tips/src/tests.rs
@@ -19,468 +19,489 @@
 
 #![cfg(test)]
 
-use crate as tips;
 use super::*;
+use crate as pallet_tips;
 use std::cell::RefCell;
 use frame_support::{assert_noop, assert_ok, parameter_types, weights::Weight, traits::Contains};
 use sp_runtime::Permill;
 use sp_core::H256;
 use sp_runtime::{
-	Perbill, ModuleId,
-	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup, BadOrigin},
+    Perbill, ModuleId,
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup, BadOrigin},
 };
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+    pub const MaximumBlockWeight: Weight = 1024;
+    pub const MaximumBlockLength: u32 = 2 * 1024;
+    pub const AvailableBlockRatio: Perbill = Perbill::one();
+}
+impl frame_system::Config for Test {
+    type BaseCallFilter = ();
+    type BlockWeights = ();
+    type BlockLength = ();
+    type DbWeight = ();
+    type Origin = Origin;
+    type Index = u64;
+    type BlockNumber = u64;
+    type Call = Call;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = u128; // u64 is not enough to hold bytes used to generate bounty account
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = Event;
+    type BlockHashCount = BlockHashCount;
+    type Version = ();
+    type PalletInfo = PalletInfo;
+    type AccountData = pallet_balances::AccountData<u64>;
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+    type SS58Prefix = ();
+}
+parameter_types! {
+    pub const ExistentialDeposit: u64 = 1;
+}
+impl pallet_balances::Config for Test {
+    type MaxLocks = ();
+    type Balance = u64;
+    type Event = Event;
+    type DustRemoval = ();
+    type ExistentialDeposit = ExistentialDeposit;
+    type AccountStore = System;
+    type WeightInfo = ();
+}
+thread_local! {
+    static TEN_TO_FOURTEEN: RefCell<Vec<u128>> = RefCell::new(vec![10,11,12,13,14]);
+}
+pub struct TenToFourteen;
+impl Contains<u128> for TenToFourteen {
+    fn sorted_members() -> Vec<u128> {
+        TEN_TO_FOURTEEN.with(|v| {
+            v.borrow().clone()
+        })
+    }
+    #[cfg(feature = "runtime-benchmarks")]
+    fn add(new: &u128) {
+        TEN_TO_FOURTEEN.with(|v| {
+            let mut members = v.borrow_mut();
+            members.push(*new);
+            members.sort();
+        })
+    }
+}
+impl ContainsLengthBound for TenToFourteen {
+    fn max_len() -> usize {
+        TEN_TO_FOURTEEN.with(|v| v.borrow().len())
+    }
+    fn min_len() -> usize { 0 }
+}
+parameter_types! {
+    pub const ProposalBond: Permill = Permill::from_percent(5);
+    pub const ProposalBondMinimum: u64 = 1;
+    pub const SpendPeriod: u64 = 2;
+    pub const Burn: Permill = Permill::from_percent(50);
+    pub const DataDepositPerByte: u64 = 1;
+    pub const TreasuryModuleId: ModuleId = ModuleId(*b"py/trsry");
+    pub const MaximumReasonLength: u32 = 16384;
+}
+impl pallet_treasury::Config for Test {
+    type ModuleId = TreasuryModuleId;
+    type Currency = pallet_balances::Pallet<Test>;
+    type ApproveOrigin = frame_system::EnsureRoot<u128>;
+    type RejectOrigin = frame_system::EnsureRoot<u128>;
+    type Event = Event;
+    type OnSlash = ();
+    type ProposalBond = ProposalBond;
+    type ProposalBondMinimum = ProposalBondMinimum;
+    type SpendPeriod = SpendPeriod;
+    type Burn = Burn;
+    type BurnDestination = ();  // Just gets burned.
+    type WeightInfo = ();
+    type SpendFunds = ();
+}
+parameter_types! {
+    pub const TipCountdown: u64 = 1;
+    pub const TipFindersFee: Percent = Percent::from_percent(20);
+    pub const TipReportDepositBase: u64 = 1;
+}
+impl Config for Test {
+    type MaximumReasonLength = MaximumReasonLength;
+    type Tippers = TenToFourteen;
+    type TipCountdown = TipCountdown;
+    type TipFindersFee = TipFindersFee;
+    type TipReportDepositBase = TipReportDepositBase;
+    type DataDepositPerByte = DataDepositPerByte;
+    type Event = Event;
+    type WeightInfo = ();
+}
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
-	pub enum Test where
-		Block = Block,
-		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
-	{
-		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
-		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-		Treasury: pallet_treasury::{Pallet, Call, Storage, Config, Event<T>},
-		TipsModTestInst: tips::{Pallet, Call, Storage, Event<T>},
-	}
+    pub enum Test where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic,
+    {
+        System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+        Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+        Treasury: pallet_treasury::{Pallet, Call, Storage, Config<T>, Event<T>},
+        Tips: pallet_tips::{Pallet, Call, Storage, Event<T>},
+    }
 );
 
-parameter_types! {
-	pub const BlockHashCount: u64 = 250;
-	pub const MaximumBlockWeight: Weight = 1024;
-	pub const MaximumBlockLength: u32 = 2 * 1024;
-	pub const AvailableBlockRatio: Perbill = Perbill::one();
-}
-impl frame_system::Config for Test {
-	type BaseCallFilter = ();
-	type BlockWeights = ();
-	type BlockLength = ();
-	type DbWeight = ();
-	type Origin = Origin;
-	type Index = u64;
-	type BlockNumber = u64;
-	type Call = Call;
-	type Hash = H256;
-	type Hashing = BlakeTwo256;
-	type AccountId = u128; // u64 is not enough to hold bytes used to generate bounty account
-	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
-	type Event = Event;
-	type BlockHashCount = BlockHashCount;
-	type Version = ();
-	type PalletInfo = PalletInfo;
-	type AccountData = pallet_balances::AccountData<u64>;
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
-	type SystemWeightInfo = ();
-	type SS58Prefix = ();
-}
-parameter_types! {
-	pub const ExistentialDeposit: u64 = 1;
-}
-impl pallet_balances::Config for Test {
-	type MaxLocks = ();
-	type Balance = u64;
-	type Event = Event;
-	type DustRemoval = ();
-	type ExistentialDeposit = ExistentialDeposit;
-	type AccountStore = System;
-	type WeightInfo = ();
-}
-thread_local! {
-	static TEN_TO_FOURTEEN: RefCell<Vec<u128>> = RefCell::new(vec![10,11,12,13,14]);
-}
-pub struct TenToFourteen;
-impl Contains<u128> for TenToFourteen {
-	fn sorted_members() -> Vec<u128> {
-		TEN_TO_FOURTEEN.with(|v| {
-			v.borrow().clone()
-		})
-	}
-	#[cfg(feature = "runtime-benchmarks")]
-	fn add(new: &u128) {
-		TEN_TO_FOURTEEN.with(|v| {
-			let mut members = v.borrow_mut();
-			members.push(*new);
-			members.sort();
-		})
-	}
-}
-impl ContainsLengthBound for TenToFourteen {
-	fn max_len() -> usize {
-		TEN_TO_FOURTEEN.with(|v| v.borrow().len())
-	}
-	fn min_len() -> usize { 0 }
-}
-parameter_types! {
-	pub const ProposalBond: Permill = Permill::from_percent(5);
-	pub const ProposalBondMinimum: u64 = 1;
-	pub const SpendPeriod: u64 = 2;
-	pub const Burn: Permill = Permill::from_percent(50);
-	pub const DataDepositPerByte: u64 = 1;
-	pub const TreasuryModuleId: ModuleId = ModuleId(*b"py/trsry");
-	pub const MaximumReasonLength: u32 = 16384;
-}
-impl pallet_treasury::Config for Test {
-	type ModuleId = TreasuryModuleId;
-	type Currency = pallet_balances::Pallet<Test>;
-	type ApproveOrigin = frame_system::EnsureRoot<u128>;
-	type RejectOrigin = frame_system::EnsureRoot<u128>;
-	type Event = Event;
-	type OnSlash = ();
-	type ProposalBond = ProposalBond;
-	type ProposalBondMinimum = ProposalBondMinimum;
-	type SpendPeriod = SpendPeriod;
-	type Burn = Burn;
-	type BurnDestination = ();  // Just gets burned.
-	type WeightInfo = ();
-	type SpendFunds = ();
-}
-parameter_types! {
-	pub const TipCountdown: u64 = 1;
-	pub const TipFindersFee: Percent = Percent::from_percent(20);
-	pub const TipReportDepositBase: u64 = 1;
-}
-impl Config for Test {
-	type MaximumReasonLength = MaximumReasonLength;
-	type Tippers = TenToFourteen;
-	type TipCountdown = TipCountdown;
-	type TipFindersFee = TipFindersFee;
-	type TipReportDepositBase = TipReportDepositBase;
-	type DataDepositPerByte = DataDepositPerByte;
-	type Event = Event;
-	type WeightInfo = ();
-}
-
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
-	pallet_balances::GenesisConfig::<Test>{
-		// Total issuance will be 200 with treasury account initialized at ED.
-		balances: vec![(0, 100), (1, 98), (2, 1)],
-	}.assimilate_storage(&mut t).unwrap();
-	pallet_treasury::GenesisConfig::default().assimilate_storage::<Test, _>(&mut t).unwrap();
-	t.into()
+    let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+
+    pallet_balances::GenesisConfig::<Test> {
+        balances: vec![(0, 100), (1, 98), (2, 1)],
+    }.assimilate_storage(&mut t).unwrap();
+
+    pallet_treasury::GenesisConfig::<Test, _>::default()
+        .assimilate_storage(&mut t).unwrap();
+
+    pallet_tips::GenesisConfig::<Test>::default()
+        .assimilate_storage(&mut t).unwrap();
+
+    let mut ext = sp_io::TestExternalities::new(t);
+    ext.execute_with(|| System::set_block_number(1));
+
+    ext
 }
 
-fn last_event() -> RawEvent<u64, u128, H256> {
-	System::events().into_iter().map(|r| r.event)
-		.filter_map(|e| {
-			if let Event::tips(inner) = e { Some(inner) } else { None }
-		})
-		.last()
-		.unwrap()
+fn last_event() -> Event {
+    system::Pallet::<Test>::events().pop().expect("Event expected").event
 }
 
 #[test]
 fn genesis_config_works() {
-	new_test_ext().execute_with(|| {
-		assert_eq!(Treasury::pot(), 0);
-		assert_eq!(Treasury::proposal_count(), 0);
-	});
+    new_test_ext().execute_with(|| {
+        assert_eq!(Treasury::pot(), 0);
+        assert_eq!(Treasury::proposal_count(), 0);
+    });
 }
 
 fn tip_hash() -> H256 {
-	BlakeTwo256::hash_of(&(BlakeTwo256::hash(b"awesome.dot"), 3u128))
+    BlakeTwo256::hash_of(&(BlakeTwo256::hash(b"awesome.dot"), 3u128))
 }
 
 #[test]
 fn tip_new_cannot_be_used_twice() {
-	new_test_ext().execute_with(|| {
-		Balances::make_free_balance_be(&Treasury::account_id(), 101);
-		assert_ok!(TipsModTestInst::tip_new(Origin::signed(10), b"awesome.dot".to_vec(), 3, 10));
-		assert_noop!(
-			TipsModTestInst::tip_new(Origin::signed(11), b"awesome.dot".to_vec(), 3, 10),
-			Error::<Test>::AlreadyKnown
-		);
-	});
+    new_test_ext().execute_with(|| {
+        Balances::make_free_balance_be(&Treasury::account_id(), 101);
+        assert_ok!(Tips::tip_new(Origin::signed(10), b"awesome.dot".to_vec(), 3, 10));
+        assert_noop!(
+            Tips::tip_new(Origin::signed(11), b"awesome.dot".to_vec(), 3, 10),
+            Error::<Test>::AlreadyKnown
+        );
+    });
 }
 
 #[test]
 fn report_awesome_and_tip_works() {
-	new_test_ext().execute_with(|| {
-		Balances::make_free_balance_be(&Treasury::account_id(), 101);
-		assert_ok!(TipsModTestInst::report_awesome(Origin::signed(0), b"awesome.dot".to_vec(), 3));
-		assert_eq!(Balances::reserved_balance(0), 12);
-		assert_eq!(Balances::free_balance(0), 88);
+    new_test_ext().execute_with(|| {
+        Balances::make_free_balance_be(&Treasury::account_id(), 101);
+        assert_ok!(Tips::report_awesome(Origin::signed(0), b"awesome.dot".to_vec(), 3));
+        assert_eq!(Balances::reserved_balance(0), 12);
+        assert_eq!(Balances::free_balance(0), 88);
 
-		// other reports don't count.
-		assert_noop!(
-			TipsModTestInst::report_awesome(Origin::signed(1), b"awesome.dot".to_vec(), 3),
-			Error::<Test>::AlreadyKnown
-		);
+        // other reports don't count.
+        assert_noop!(
+            Tips::report_awesome(Origin::signed(1), b"awesome.dot".to_vec(), 3),
+            Error::<Test>::AlreadyKnown
+        );
 
-		let h = tip_hash();
-		assert_ok!(TipsModTestInst::tip(Origin::signed(10), h.clone(), 10));
-		assert_ok!(TipsModTestInst::tip(Origin::signed(11), h.clone(), 10));
-		assert_ok!(TipsModTestInst::tip(Origin::signed(12), h.clone(), 10));
-		assert_noop!(TipsModTestInst::tip(Origin::signed(9), h.clone(), 10), BadOrigin);
-		System::set_block_number(2);
-		assert_ok!(TipsModTestInst::close_tip(Origin::signed(100), h.into()));
-		assert_eq!(Balances::reserved_balance(0), 0);
-		assert_eq!(Balances::free_balance(0), 102);
-		assert_eq!(Balances::free_balance(3), 8);
-	});
+        let h = tip_hash();
+        assert_ok!(Tips::tip(Origin::signed(10), h.clone(), 10));
+        assert_ok!(Tips::tip(Origin::signed(11), h.clone(), 10));
+        assert_ok!(Tips::tip(Origin::signed(12), h.clone(), 10));
+        assert_noop!(Tips::tip(Origin::signed(9), h.clone(), 10), BadOrigin);
+        System::set_block_number(2);
+        assert_ok!(Tips::close_tip(Origin::signed(100), h.into()));
+        assert_eq!(Balances::reserved_balance(0), 0);
+        assert_eq!(Balances::free_balance(0), 102);
+        assert_eq!(Balances::free_balance(3), 8);
+    });
 }
 
 #[test]
 fn report_awesome_from_beneficiary_and_tip_works() {
-	new_test_ext().execute_with(|| {
-		Balances::make_free_balance_be(&Treasury::account_id(), 101);
-		assert_ok!(TipsModTestInst::report_awesome(Origin::signed(0), b"awesome.dot".to_vec(), 0));
-		assert_eq!(Balances::reserved_balance(0), 12);
-		assert_eq!(Balances::free_balance(0), 88);
-		let h = BlakeTwo256::hash_of(&(BlakeTwo256::hash(b"awesome.dot"), 0u128));
-		assert_ok!(TipsModTestInst::tip(Origin::signed(10), h.clone(), 10));
-		assert_ok!(TipsModTestInst::tip(Origin::signed(11), h.clone(), 10));
-		assert_ok!(TipsModTestInst::tip(Origin::signed(12), h.clone(), 10));
-		System::set_block_number(2);
-		assert_ok!(TipsModTestInst::close_tip(Origin::signed(100), h.into()));
-		assert_eq!(Balances::reserved_balance(0), 0);
-		assert_eq!(Balances::free_balance(0), 110);
-	});
+    new_test_ext().execute_with(|| {
+        Balances::make_free_balance_be(&Treasury::account_id(), 101);
+        assert_ok!(Tips::report_awesome(Origin::signed(0), b"awesome.dot".to_vec(), 0));
+        assert_eq!(Balances::reserved_balance(0), 12);
+        assert_eq!(Balances::free_balance(0), 88);
+        let h = BlakeTwo256::hash_of(&(BlakeTwo256::hash(b"awesome.dot"), 0u128));
+        assert_ok!(Tips::tip(Origin::signed(10), h.clone(), 10));
+        assert_ok!(Tips::tip(Origin::signed(11), h.clone(), 10));
+        assert_ok!(Tips::tip(Origin::signed(12), h.clone(), 10));
+        System::set_block_number(2);
+        assert_ok!(Tips::close_tip(Origin::signed(100), h.into()));
+        assert_eq!(Balances::reserved_balance(0), 0);
+        assert_eq!(Balances::free_balance(0), 110);
+    });
 }
 
 #[test]
 fn close_tip_works() {
-	new_test_ext().execute_with(|| {
-		System::set_block_number(1);
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
 
-		Balances::make_free_balance_be(&Treasury::account_id(), 101);
-		assert_eq!(Treasury::pot(), 100);
+        Balances::make_free_balance_be(&Treasury::account_id(), 101);
+        assert_eq!(Treasury::pot(), 100);
 
-		assert_ok!(TipsModTestInst::tip_new(Origin::signed(10), b"awesome.dot".to_vec(), 3, 10));
+        assert_ok!(Tips::tip_new(Origin::signed(10), b"awesome.dot".to_vec(), 3, 10));
 
-		let h = tip_hash();
+        let h = tip_hash();
 
-		assert_eq!(last_event(), RawEvent::NewTip(h));
+        assert_eq!(
+            last_event(),
+            Event::pallet_tips(crate::Event::NewTip(h)),
+        );
 
-		assert_ok!(TipsModTestInst::tip(Origin::signed(11), h.clone(), 10));
+        assert_ok!(Tips::tip(Origin::signed(11), h.clone(), 10));
 
-		assert_noop!(TipsModTestInst::close_tip(Origin::signed(0), h.into()), Error::<Test>::StillOpen);
+        assert_noop!(Tips::close_tip(Origin::signed(0), h.into()), Error::<Test>::StillOpen);
 
-		assert_ok!(TipsModTestInst::tip(Origin::signed(12), h.clone(), 10));
+        assert_ok!(Tips::tip(Origin::signed(12), h.clone(), 10));
 
-		assert_eq!(last_event(), RawEvent::TipClosing(h));
+        assert_eq!(
+            last_event(),
+            Event::pallet_tips(crate::Event::TipClosing(h)),
+        );
 
-		assert_noop!(TipsModTestInst::close_tip(Origin::signed(0), h.into()), Error::<Test>::Premature);
+        assert_noop!(Tips::close_tip(Origin::signed(0), h.into()), Error::<Test>::Premature);
 
-		System::set_block_number(2);
-		assert_noop!(TipsModTestInst::close_tip(Origin::none(), h.into()), BadOrigin);
-		assert_ok!(TipsModTestInst::close_tip(Origin::signed(0), h.into()));
-		assert_eq!(Balances::free_balance(3), 10);
+        System::set_block_number(2);
+        assert_noop!(Tips::close_tip(Origin::none(), h.into()), BadOrigin);
+        assert_ok!(Tips::close_tip(Origin::signed(0), h.into()));
+        assert_eq!(Balances::free_balance(3), 10);
 
-		assert_eq!(last_event(), RawEvent::TipClosed(h, 3, 10));
+        assert_eq!(
+            last_event(),
+            Event::pallet_tips(crate::Event::TipClosed(h, 3, 10)),
+        );
 
-		assert_noop!(TipsModTestInst::close_tip(Origin::signed(100), h.into()), Error::<Test>::UnknownTip);
-	});
+        assert_noop!(Tips::close_tip(Origin::signed(100), h.into()), Error::<Test>::UnknownTip);
+    });
 }
 
 #[test]
 fn slash_tip_works() {
-	new_test_ext().execute_with(|| {
-		System::set_block_number(1);
-		Balances::make_free_balance_be(&Treasury::account_id(), 101);
-		assert_eq!(Treasury::pot(), 100);
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+        Balances::make_free_balance_be(&Treasury::account_id(), 101);
+        assert_eq!(Treasury::pot(), 100);
 
-		assert_eq!(Balances::reserved_balance(0), 0);
-		assert_eq!(Balances::free_balance(0), 100);
+        assert_eq!(Balances::reserved_balance(0), 0);
+        assert_eq!(Balances::free_balance(0), 100);
 
-		assert_ok!(TipsModTestInst::report_awesome(Origin::signed(0), b"awesome.dot".to_vec(), 3));
+        assert_ok!(Tips::report_awesome(Origin::signed(0), b"awesome.dot".to_vec(), 3));
 
-		assert_eq!(Balances::reserved_balance(0), 12);
-		assert_eq!(Balances::free_balance(0), 88);
+        assert_eq!(Balances::reserved_balance(0), 12);
+        assert_eq!(Balances::free_balance(0), 88);
 
-		let h = tip_hash();
-		assert_eq!(last_event(), RawEvent::NewTip(h));
+        let h = tip_hash();
+        assert_eq!(
+            last_event(),
+            Event::pallet_tips(crate::Event::NewTip(h)),
+        );
 
-		// can't remove from any origin
-		assert_noop!(
-			TipsModTestInst::slash_tip(Origin::signed(0), h.clone()),
-			BadOrigin,
-		);
+        // can't remove from any origin
+        assert_noop!(
+            Tips::slash_tip(Origin::signed(0), h.clone()),
+            BadOrigin,
+        );
 
-		// can remove from root.
-		assert_ok!(TipsModTestInst::slash_tip(Origin::root(), h.clone()));
-		assert_eq!(last_event(), RawEvent::TipSlashed(h, 0, 12));
+        // can remove from root.
+        assert_ok!(Tips::slash_tip(Origin::root(), h.clone()));
+        assert_eq!(
+            last_event(),
+            Event::pallet_tips(crate::Event::TipSlashed(h, 0, 12)),
+        );
 
-		// tipper slashed
-		assert_eq!(Balances::reserved_balance(0), 0);
-		assert_eq!(Balances::free_balance(0), 88);
-	});
+        // tipper slashed
+        assert_eq!(Balances::reserved_balance(0), 0);
+        assert_eq!(Balances::free_balance(0), 88);
+    });
 }
 
 #[test]
 fn retract_tip_works() {
-	new_test_ext().execute_with(|| {
-		// with report awesome
-		Balances::make_free_balance_be(&Treasury::account_id(), 101);
-		assert_ok!(TipsModTestInst::report_awesome(Origin::signed(0), b"awesome.dot".to_vec(), 3));
-		let h = tip_hash();
-		assert_ok!(TipsModTestInst::tip(Origin::signed(10), h.clone(), 10));
-		assert_ok!(TipsModTestInst::tip(Origin::signed(11), h.clone(), 10));
-		assert_ok!(TipsModTestInst::tip(Origin::signed(12), h.clone(), 10));
-		assert_noop!(TipsModTestInst::retract_tip(Origin::signed(10), h.clone()), Error::<Test>::NotFinder);
-		assert_ok!(TipsModTestInst::retract_tip(Origin::signed(0), h.clone()));
-		System::set_block_number(2);
-		assert_noop!(TipsModTestInst::close_tip(Origin::signed(0), h.into()), Error::<Test>::UnknownTip);
+    new_test_ext().execute_with(|| {
+        // with report awesome
+        Balances::make_free_balance_be(&Treasury::account_id(), 101);
+        assert_ok!(Tips::report_awesome(Origin::signed(0), b"awesome.dot".to_vec(), 3));
+        let h = tip_hash();
+        assert_ok!(Tips::tip(Origin::signed(10), h.clone(), 10));
+        assert_ok!(Tips::tip(Origin::signed(11), h.clone(), 10));
+        assert_ok!(Tips::tip(Origin::signed(12), h.clone(), 10));
+        assert_noop!(Tips::retract_tip(Origin::signed(10), h.clone()), Error::<Test>::NotFinder);
+        assert_ok!(Tips::retract_tip(Origin::signed(0), h.clone()));
+        System::set_block_number(2);
+        assert_noop!(Tips::close_tip(Origin::signed(0), h.into()), Error::<Test>::UnknownTip);
 
-		// with tip new
-		Balances::make_free_balance_be(&Treasury::account_id(), 101);
-		assert_ok!(TipsModTestInst::tip_new(Origin::signed(10), b"awesome.dot".to_vec(), 3, 10));
-		let h = tip_hash();
-		assert_ok!(TipsModTestInst::tip(Origin::signed(11), h.clone(), 10));
-		assert_ok!(TipsModTestInst::tip(Origin::signed(12), h.clone(), 10));
-		assert_noop!(TipsModTestInst::retract_tip(Origin::signed(0), h.clone()), Error::<Test>::NotFinder);
-		assert_ok!(TipsModTestInst::retract_tip(Origin::signed(10), h.clone()));
-		System::set_block_number(2);
-		assert_noop!(TipsModTestInst::close_tip(Origin::signed(10), h.into()), Error::<Test>::UnknownTip);
-	});
+        // with tip new
+        Balances::make_free_balance_be(&Treasury::account_id(), 101);
+        assert_ok!(Tips::tip_new(Origin::signed(10), b"awesome.dot".to_vec(), 3, 10));
+        let h = tip_hash();
+        assert_ok!(Tips::tip(Origin::signed(11), h.clone(), 10));
+        assert_ok!(Tips::tip(Origin::signed(12), h.clone(), 10));
+        assert_noop!(Tips::retract_tip(Origin::signed(0), h.clone()), Error::<Test>::NotFinder);
+        assert_ok!(Tips::retract_tip(Origin::signed(10), h.clone()));
+        System::set_block_number(2);
+        assert_noop!(Tips::close_tip(Origin::signed(10), h.into()), Error::<Test>::UnknownTip);
+    });
 }
 
 #[test]
 fn tip_median_calculation_works() {
-	new_test_ext().execute_with(|| {
-		Balances::make_free_balance_be(&Treasury::account_id(), 101);
-		assert_ok!(TipsModTestInst::tip_new(Origin::signed(10), b"awesome.dot".to_vec(), 3, 0));
-		let h = tip_hash();
-		assert_ok!(TipsModTestInst::tip(Origin::signed(11), h.clone(), 10));
-		assert_ok!(TipsModTestInst::tip(Origin::signed(12), h.clone(), 1000000));
-		System::set_block_number(2);
-		assert_ok!(TipsModTestInst::close_tip(Origin::signed(0), h.into()));
-		assert_eq!(Balances::free_balance(3), 10);
-	});
+    new_test_ext().execute_with(|| {
+        Balances::make_free_balance_be(&Treasury::account_id(), 101);
+        assert_ok!(Tips::tip_new(Origin::signed(10), b"awesome.dot".to_vec(), 3, 0));
+        let h = tip_hash();
+        assert_ok!(Tips::tip(Origin::signed(11), h.clone(), 10));
+        assert_ok!(Tips::tip(Origin::signed(12), h.clone(), 1000000));
+        System::set_block_number(2);
+        assert_ok!(Tips::close_tip(Origin::signed(0), h.into()));
+        assert_eq!(Balances::free_balance(3), 10);
+    });
 }
 
 #[test]
 fn tip_changing_works() {
-	new_test_ext().execute_with(|| {
-		Balances::make_free_balance_be(&Treasury::account_id(), 101);
-		assert_ok!(TipsModTestInst::tip_new(Origin::signed(10), b"awesome.dot".to_vec(), 3, 10000));
-		let h = tip_hash();
-		assert_ok!(TipsModTestInst::tip(Origin::signed(11), h.clone(), 10000));
-		assert_ok!(TipsModTestInst::tip(Origin::signed(12), h.clone(), 10000));
-		assert_ok!(TipsModTestInst::tip(Origin::signed(13), h.clone(), 0));
-		assert_ok!(TipsModTestInst::tip(Origin::signed(14), h.clone(), 0));
-		assert_ok!(TipsModTestInst::tip(Origin::signed(12), h.clone(), 1000));
-		assert_ok!(TipsModTestInst::tip(Origin::signed(11), h.clone(), 100));
-		assert_ok!(TipsModTestInst::tip(Origin::signed(10), h.clone(), 10));
-		System::set_block_number(2);
-		assert_ok!(TipsModTestInst::close_tip(Origin::signed(0), h.into()));
-		assert_eq!(Balances::free_balance(3), 10);
-	});
+    new_test_ext().execute_with(|| {
+        Balances::make_free_balance_be(&Treasury::account_id(), 101);
+        assert_ok!(Tips::tip_new(Origin::signed(10), b"awesome.dot".to_vec(), 3, 10000));
+        let h = tip_hash();
+        assert_ok!(Tips::tip(Origin::signed(11), h.clone(), 10000));
+        assert_ok!(Tips::tip(Origin::signed(12), h.clone(), 10000));
+        assert_ok!(Tips::tip(Origin::signed(13), h.clone(), 0));
+        assert_ok!(Tips::tip(Origin::signed(14), h.clone(), 0));
+        assert_ok!(Tips::tip(Origin::signed(12), h.clone(), 1000));
+        assert_ok!(Tips::tip(Origin::signed(11), h.clone(), 100));
+        assert_ok!(Tips::tip(Origin::signed(10), h.clone(), 10));
+        System::set_block_number(2);
+        assert_ok!(Tips::close_tip(Origin::signed(0), h.into()));
+        assert_eq!(Balances::free_balance(3), 10);
+    });
 }
 
 #[test]
 fn test_last_reward_migration() {
-	use sp_storage::Storage;
+    use sp_storage::Storage;
 
-	let mut s = Storage::default();
+    let mut s = Storage::default();
 
-	#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
-	pub struct OldOpenTip<
-		AccountId: Parameter,
-		Balance: Parameter,
-		BlockNumber: Parameter,
-		Hash: Parameter,
-	> {
-		/// The hash of the reason for the tip. The reason should be a human-readable UTF-8 encoded string. A URL would be
-		/// sensible.
-		reason: Hash,
-		/// The account to be tipped.
-		who: AccountId,
-		/// The account who began this tip and the amount held on deposit.
-		finder: Option<(AccountId, Balance)>,
-		/// The block number at which this tip will close if `Some`. If `None`, then no closing is
-		/// scheduled.
-		closes: Option<BlockNumber>,
-		/// The members who have voted for this tip. Sorted by AccountId.
-		tips: Vec<(AccountId, Balance)>,
-	}
+    #[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+    pub struct OldOpenTip<
+        AccountId: Parameter,
+        Balance: Parameter,
+        BlockNumber: Parameter,
+        Hash: Parameter,
+    > {
+        /// The hash of the reason for the tip. The reason should be a human-readable UTF-8 encoded string. A URL would be
+        /// sensible.
+        reason: Hash,
+        /// The account to be tipped.
+        who: AccountId,
+        /// The account who began this tip and the amount held on deposit.
+        finder: Option<(AccountId, Balance)>,
+        /// The block number at which this tip will close if `Some`. If `None`, then no closing is
+        /// scheduled.
+        closes: Option<BlockNumber>,
+        /// The members who have voted for this tip. Sorted by AccountId.
+        tips: Vec<(AccountId, Balance)>,
+    }
 
-	let reason1 = BlakeTwo256::hash(b"reason1");
-	let hash1 = BlakeTwo256::hash_of(&(reason1, 10u64));
+    let reason1 = BlakeTwo256::hash(b"reason1");
+    let hash1 = BlakeTwo256::hash_of(&(reason1, 10u64));
 
-	let old_tip_finder = OldOpenTip::<u128, u64, u64, H256> {
-		reason: reason1,
-		who: 10,
-		finder: Some((20, 30)),
-		closes: Some(13),
-		tips: vec![(40, 50), (60, 70)]
-	};
+    let old_tip_finder = OldOpenTip::<u128, u64, u64, H256> {
+        reason: reason1,
+        who: 10,
+        finder: Some((20, 30)),
+        closes: Some(13),
+        tips: vec![(40, 50), (60, 70)]
+    };
 
-	let reason2 = BlakeTwo256::hash(b"reason2");
-	let hash2 = BlakeTwo256::hash_of(&(reason2, 20u64));
+    let reason2 = BlakeTwo256::hash(b"reason2");
+    let hash2 = BlakeTwo256::hash_of(&(reason2, 20u64));
 
-	let old_tip_no_finder = OldOpenTip::<u128, u64, u64, H256> {
-		reason: reason2,
-		who: 20,
-		finder: None,
-		closes: Some(13),
-		tips: vec![(40, 50), (60, 70)]
-	};
+    let old_tip_no_finder = OldOpenTip::<u128, u64, u64, H256> {
+        reason: reason2,
+        who: 20,
+        finder: None,
+        closes: Some(13),
+        tips: vec![(40, 50), (60, 70)]
+    };
 
-	let data = vec![
-		(
-			Tips::<Test>::hashed_key_for(hash1),
-			old_tip_finder.encode().to_vec()
-		),
-		(
-			Tips::<Test>::hashed_key_for(hash2),
-			old_tip_no_finder.encode().to_vec()
-		),
-	];
+    let data = vec![
+        (
+            pallet_tips::Tips::<Test>::hashed_key_for(hash1),
+            old_tip_finder.encode().to_vec()
+        ),
+        (
+            pallet_tips::Tips::<Test>::hashed_key_for(hash2),
+            old_tip_no_finder.encode().to_vec()
+        ),
+    ];
 
-	s.top = data.into_iter().collect();
+    s.top = data.into_iter().collect();
 
-	sp_io::TestExternalities::new(s).execute_with(|| {
+    sp_io::TestExternalities::new(s).execute_with(|| {
 
-		TipsModTestInst::migrate_retract_tip_for_tip_new();
+        Tips::migrate_retract_tip_for_tip_new();
 
-		// Test w/ finder
-		assert_eq!(
-			Tips::<Test>::get(hash1),
-			Some(OpenTip {
-				reason: reason1,
-				who: 10,
-				finder: 20,
-				deposit: 30,
-				closes: Some(13),
-				tips: vec![(40, 50), (60, 70)],
-				finders_fee: true,
-			})
-		);
+        // Test w/ finder
+        assert_eq!(
+            pallet_tips::Tips::<Test>::get(hash1),
+            Some(OpenTip {
+                reason: reason1,
+                who: 10,
+                finder: 20,
+                deposit: 30,
+                closes: Some(13),
+                tips: vec![(40, 50), (60, 70)],
+                finders_fee: true,
+            })
+        );
 
-		// Test w/o finder
-		assert_eq!(
-			Tips::<Test>::get(hash2),
-			Some(OpenTip {
-				reason: reason2,
-				who: 20,
-				finder: Default::default(),
-				deposit: 0,
-				closes: Some(13),
-				tips: vec![(40, 50), (60, 70)],
-				finders_fee: false,
-			})
-		);
-	});
+        // Test w/o finder
+        assert_eq!(
+            pallet_tips::Tips::<Test>::get(hash2),
+            Some(OpenTip {
+                reason: reason2,
+                who: 20,
+                finder: Default::default(),
+                deposit: 0,
+                closes: Some(13),
+                tips: vec![(40, 50), (60, 70)],
+                finders_fee: false,
+            })
+        );
+    });
 }
 
 #[test]
 fn genesis_funding_works() {
-	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
-	let initial_funding = 100;
-	pallet_balances::GenesisConfig::<Test>{
-		// Total issuance will be 200 with treasury account initialized with 100.
-		balances: vec![(0, 100), (Treasury::account_id(), initial_funding)],
-	}.assimilate_storage(&mut t).unwrap();
-	pallet_treasury::GenesisConfig::default().assimilate_storage::<Test, _>(&mut t).unwrap();
-	let mut t: sp_io::TestExternalities = t.into();
+    let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+    let initial_funding = 100;
+    pallet_balances::GenesisConfig::<Test>{
+        // Total issuance will be 200 with treasury account initialized with 100.
+        balances: vec![(0, 100), (Treasury::account_id(), initial_funding)],
+    }.assimilate_storage(&mut t).unwrap();
 
-	t.execute_with(|| {
-		assert_eq!(Balances::free_balance(Treasury::account_id()), initial_funding);
-		assert_eq!(Treasury::pot(), initial_funding - Balances::minimum_balance());
-	});
+    pallet_treasury::GenesisConfig::<Test, _>::default()
+        .assimilate_storage(&mut t).unwrap();
+
+    let mut t: sp_io::TestExternalities = t.into();
+
+    t.execute_with(|| {
+        assert_eq!(Balances::free_balance(Treasury::account_id()), initial_funding);
+        assert_eq!(Treasury::pot(), initial_funding - Balances::minimum_balance());
+    });
 }


### PR DESCRIPTION
# pallet-tips | port to frame v2

related #7882 | Has dependency on  #8196 , #8193

:warning: Breaking Change :warning:

From https://crates.parity.io/frame_support/attr.pallet.html#checking-upgrade-guidelines

```
storages now use PalletInfo for module_prefix instead of the one given to decl_storage: 
Thus any use of this pallet in construct_runtime! should be careful to update name 
in order not to break storage or to upgrade storage (moreover for instantiable pallet). 
If pallet is published, make sure to warn about this breaking change.
```

So users of the treasury pallet must be careful about the name they used in construct_runtime!. Hence, the runtime-migration label, which might not be needed depending on the configuration of the treasury pallet.
